### PR TITLE
store introspection queries

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,6 @@
     "space-before-function-paren": [2, "never"],
     "object-curly-spacing": [2, "always"],
     "array-bracket-spacing": [2, "never"],
-    "no-console": 2,
     "mocha/no-exclusive-tests": 2,
     "mocha/no-global-tests": 2,
     "mocha/no-hooks-for-single-case": 2,

--- a/README.md
+++ b/README.md
@@ -197,6 +197,18 @@ const validationErrorFn = (req) => {
 app.post('/graphql', graphqlWhitelist({ store, validationErrorFn }))
 ```
 
+### storeIntrospectionQueries
+
+If this option is set to true, `graphql-query-whitelist` will add to the whitelist all GraphQL and GraphiQL introspection queries.
+
+This option is disabled by default, but is needed if you are using GraphiQL and need to have the introspection queries whitelisted in order to have the autocompletion feature working.
+
+Example:
+
+```js
+app.post('/graphql', graphqlWhitelist({ store, storeIntrospectionQueries: true }))
+```
+
 ## License
 
 Copyright (c) 2016 Restorando

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,10 @@ const noop = () => { }
 
 export default ({ store, skipValidationFn = noop, validationErrorFn = noop, storeIntrospectionQueries = false }) => {
   const repository = new QueryRepository(store)
+  let storeIQPromise = Promise.resolve()
 
   if (storeIntrospectionQueries) {
-    storeQueries(repository)
+    storeIQPromise = storeQueries(repository)
   }
 
   return async (req, res, next) => {
@@ -21,6 +22,8 @@ export default ({ store, skipValidationFn = noop, validationErrorFn = noop, stor
     try {
       const queryId = req.body.queryId || req.query.queryId
       let queryObj = {}
+
+      await storeIQPromise
 
       if (queryId) {
         queryObj = { queryId }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,7 @@ const noop = () => { }
 
 export default ({ store, skipValidationFn = noop, validationErrorFn = noop, storeIntrospectionQueries = false }) => {
   const repository = new QueryRepository(store)
-  let storeIQPromise = Promise.resolve()
-
-  if (storeIntrospectionQueries) {
-    storeIQPromise = storeQueries(repository)
-  }
+  const storeIQPromise = storeIntrospectionQueries ? storeQueries(repository) : Promise.resolve()
 
   return async (req, res, next) => {
     const unauthorized = (errorCode, error = { message: 'Unauthorized query' }, statusCode = 401) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,31 +1,36 @@
-import { parseQuery, QueryRepository, QueryNotFoundError } from './utils'
+import { parseQuery, QueryRepository, QueryNotFoundError, storeIntrospectionQueries as storeQueries } from './utils'
+import { formatError } from 'graphql'
 
 const noop = () => { }
 
-export default ({ store, skipValidationFn = noop, validationErrorFn = noop }) => {
+export default ({ store, skipValidationFn = noop, validationErrorFn = noop, storeIntrospectionQueries = false }) => {
   const repository = new QueryRepository(store)
 
+  if (storeIntrospectionQueries) {
+    storeQueries(repository)
+  }
+
   return async (req, res, next) => {
-    const unauthorized = (errorCode) => {
+    const unauthorized = (errorCode, error = { message: 'Unauthorized query' }, statusCode = 401) => {
       validationErrorFn(req, { errorCode })
-      res.status(401).json({ error: 'Unauthorized query' })
+      res.status(statusCode).json({ errors: [formatError(error)] })
     }
 
     if (skipValidationFn(req)) return next()
 
-    const queryId = req.body.queryId || req.query.queryId
-    let queryObj = {}
-
-    if (queryId) {
-      queryObj = { queryId }
-    } else if (req.body.query) {
-      queryObj = parseQuery(req.body.query, { requireOperationName: false })
-    } else {
-      // No queryId or query was specified. Let express-graphql handle this
-      next()
-    }
-
     try {
+      const queryId = req.body.queryId || req.query.queryId
+      let queryObj = {}
+
+      if (queryId) {
+        queryObj = { queryId }
+      } else if (req.body.query) {
+        queryObj = parseQuery(req.body.query, { requireOperationName: false })
+      } else {
+        // No queryId or query was specified. Let express-graphql handle this
+        next()
+      }
+
       const { query, enabled } = await repository.get(queryObj.queryId)
 
       req.queryId = queryObj.queryId
@@ -36,7 +41,7 @@ export default ({ store, skipValidationFn = noop, validationErrorFn = noop }) =>
       if (error instanceof QueryNotFoundError) {
         unauthorized('QUERY_NOT_FOUND')
       } else {
-        throw error
+        unauthorized('GRAPHQL_ERROR', error, 400)
       }
     }
   }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,2 +1,3 @@
 export parseQuery from './parse-query'
 export QueryRepository, { QueryNotFoundError } from './query-repository'
+export storeIntrospectionQueries from './store-introspection-queries'

--- a/lib/utils/queries/graphiql-introspection-query-0.4.1.graphql
+++ b/lib/utils/queries/graphiql-introspection-query-0.4.1.graphql
@@ -1,0 +1,73 @@
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      onOperation
+      onFragment
+      onField
+    }
+  }
+}
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+      }
+    }
+  }
+}

--- a/lib/utils/queries/graphiql-introspection-query-0.7.3.graphql
+++ b/lib/utils/queries/graphiql-introspection-query-0.7.3.graphql
@@ -1,0 +1,87 @@
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/utils/queries/graphql-introspection-query-0.4.10.graphql
+++ b/lib/utils/queries/graphql-introspection-query-0.4.10.graphql
@@ -1,0 +1,77 @@
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      onOperation
+      onFragment
+      onField
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+      }
+    }
+  }
+}

--- a/lib/utils/queries/graphql-introspection-query-0.4.8.graphql
+++ b/lib/utils/queries/graphql-introspection-query-0.4.8.graphql
@@ -1,0 +1,77 @@
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      onOperation
+      onFragment
+      onField
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+      }
+    }
+  }
+}

--- a/lib/utils/queries/graphql-introspection-query-0.5.0.graphql
+++ b/lib/utils/queries/graphql-introspection-query-0.5.0.graphql
@@ -1,0 +1,75 @@
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+      }
+    }
+  }
+}

--- a/lib/utils/queries/graphql-introspection-query-0.6.0.graphql
+++ b/lib/utils/queries/graphql-introspection-query-0.6.0.graphql
@@ -1,0 +1,91 @@
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/utils/query-repository.js
+++ b/lib/utils/query-repository.js
@@ -22,9 +22,10 @@ class QueryRepository {
     return { id: queryId, ...entry }
   }
 
-  async put(query) {
-    const { queryId, operationName, normalizedQuery } = parseQuery(query, { requireOperationName: false })
-    const queryObj = { query: normalizedQuery, operationName: operationName || 'Unnamed query', enabled: true }
+  async put(query, options = {}) {
+    let { queryId, operationName, normalizedQuery } = parseQuery(query, { requireOperationName: false })
+    operationName = options.operationName || operationName || 'Unnamed query'
+    const queryObj = { query: normalizedQuery, operationName, enabled: true }
     await this.store.set(queryId, queryObj)
 
     return { id: queryId, ...queryObj }

--- a/lib/utils/query-repository.js
+++ b/lib/utils/query-repository.js
@@ -23,8 +23,8 @@ class QueryRepository {
   }
 
   async put(query) {
-    const { queryId, operationName, normalizedQuery } = parseQuery(query)
-    const queryObj = { query: normalizedQuery, operationName, enabled: true }
+    const { queryId, operationName, normalizedQuery } = parseQuery(query, { requireOperationName: false })
+    const queryObj = { query: normalizedQuery, operationName: operationName || 'Unnamed query', enabled: true }
     await this.store.set(queryId, queryObj)
 
     return { id: queryId, ...queryObj }

--- a/lib/utils/store-introspection-queries.js
+++ b/lib/utils/store-introspection-queries.js
@@ -1,0 +1,32 @@
+import fs from 'fs'
+import path from 'path'
+import { introspectionQuery } from 'graphql'
+
+const resolvePath = (filename = '') => path.join(__dirname, 'queries', filename)
+
+const getQueryFiles = () => {
+  return new Promise((resolve, reject) => {
+    const directory = resolvePath()
+
+    fs.readdir(directory, (err, files) => {
+      if (err) return reject(err)
+      resolve(files.filter(file => /\.graphql$/.test(file)).map(resolvePath))
+    })
+  })
+}
+
+export default async function storeIntrospectionQueries(repository) {
+  const files = await getQueryFiles()
+
+  console.info('Storing introspection query => extracted from current graphql version')
+  repository.put(introspectionQuery)
+
+  files.forEach(file => {
+    fs.readFile(file, (err, data) => {
+      if (err) return console.warn(err)
+
+      console.info(`Storing introspection query => ${path.basename(file, '.graphql')}`)
+      repository.put(data.toString())
+    })
+  })
+}

--- a/lib/utils/store-introspection-queries.js
+++ b/lib/utils/store-introspection-queries.js
@@ -26,21 +26,19 @@ const graphqlFilenameToString = (file) => {
 
 export default async function storeIntrospectionQueries(repository) {
   const files = await getQueryFiles()
-  const promises = []
   let operationName = graphqlFilenameToString(`graphql-introspection-query-${graphqlVersion}.graphql`)
 
-  promises.push(repository.put(introspectionQuery, { operationName }))
+  return Promise.all([
+    repository.put(introspectionQuery, { operationName }),
+    ...files.map(file => {
+      fs.readFile(file, (err, data) => {
+        if (err) return console.warn(err)
 
-  files.forEach(file => {
-    fs.readFile(file, (err, data) => {
-      if (err) return console.warn(err)
+        operationName = graphqlFilenameToString(file)
 
-      operationName = graphqlFilenameToString(file)
-
-      console.info(`Storing ${operationName}`)
-      promises.push(repository.put(data.toString(), { operationName }))
+        console.info(`Storing ${operationName}`)
+        return repository.put(data.toString(), { operationName })
+      })
     })
-  })
-
-  return Promise.all(promises)
+  ])
 }

--- a/lib/utils/store-introspection-queries.js
+++ b/lib/utils/store-introspection-queries.js
@@ -8,7 +8,6 @@ const resolvePath = (filename = '') => path.join(__dirname, 'queries', filename)
 const getQueryFiles = () => {
   return new Promise((resolve, reject) => {
     const directory = resolvePath()
-    console.log(directory)
 
     fs.readdir(directory, (err, files) => {
       if (err) return reject(err)
@@ -27,11 +26,10 @@ const graphqlFilenameToString = (file) => {
 
 export default async function storeIntrospectionQueries(repository) {
   const files = await getQueryFiles()
-  let operationName = graphqlFilenameToString(`graphql-instrospection-query-${graphqlVersion}.graphql`)
+  const promises = []
+  let operationName = graphqlFilenameToString(`graphql-introspection-query-${graphqlVersion}.graphql`)
 
-  console.info(`Storing ${operationName}`)
-
-  repository.put(introspectionQuery, { operationName })
+  promises.push(repository.put(introspectionQuery, { operationName }))
 
   files.forEach(file => {
     fs.readFile(file, (err, data) => {
@@ -40,7 +38,9 @@ export default async function storeIntrospectionQueries(repository) {
       operationName = graphqlFilenameToString(file)
 
       console.info(`Storing ${operationName}`)
-      repository.put(data.toString(), { operationName })
+      promises.push(repository.put(data.toString(), { operationName }))
     })
   })
+
+  return Promise.all(promises)
 }

--- a/lib/utils/store-introspection-queries.js
+++ b/lib/utils/store-introspection-queries.js
@@ -18,7 +18,7 @@ const getQueryFiles = () => {
 export default async function storeIntrospectionQueries(repository) {
   const files = await getQueryFiles()
 
-  console.info('Storing introspection query => extracted from current graphql version')
+  console.info("Storing introspection query => GraphQL's current version")
   repository.put(introspectionQuery)
 
   files.forEach(file => {

--- a/lib/utils/store-introspection-queries.js
+++ b/lib/utils/store-introspection-queries.js
@@ -1,12 +1,14 @@
 import fs from 'fs'
 import path from 'path'
 import { introspectionQuery } from 'graphql'
+import { version as graphqlVersion } from 'graphql/package.json'
 
 const resolvePath = (filename = '') => path.join(__dirname, 'queries', filename)
 
 const getQueryFiles = () => {
   return new Promise((resolve, reject) => {
     const directory = resolvePath()
+    console.log(directory)
 
     fs.readdir(directory, (err, files) => {
       if (err) return reject(err)
@@ -15,18 +17,30 @@ const getQueryFiles = () => {
   })
 }
 
+const graphqlFilenameToString = (file) => {
+  const filename = path.basename(file, '.graphql')
+  let [, app, version] = filename.match(/^(graphi?ql).*?([\d.]+)$/)
+  app = app.replace(/[gql]/g, letter => letter.toUpperCase())
+
+  return `${app} ${version} introspection query`
+}
+
 export default async function storeIntrospectionQueries(repository) {
   const files = await getQueryFiles()
+  let operationName = graphqlFilenameToString(`graphql-instrospection-query-${graphqlVersion}.graphql`)
 
-  console.info("Storing introspection query => GraphQL's current version")
-  repository.put(introspectionQuery)
+  console.info(`Storing ${operationName}`)
+
+  repository.put(introspectionQuery, { operationName })
 
   files.forEach(file => {
     fs.readFile(file, (err, data) => {
       if (err) return console.warn(err)
 
-      console.info(`Storing introspection query => ${path.basename(file, '.graphql')}`)
-      repository.put(data.toString())
+      operationName = graphqlFilenameToString(file)
+
+      console.info(`Storing ${operationName}`)
+      repository.put(data.toString(), { operationName })
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql-query-whitelist",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A very simple GraphQL query whitelist middleware for express",
   "main": "./dist/index.js",
   "scripts": {
     "lint": "eslint .",
     "test": "NODE_ENV=test NODE_PATH=src mocha --timeout 1000 --compilers js:babel-core/register --require babel-polyfill ./test/*.js ./test/store/*.js ./test/utils/*.js",
-    "build": "babel lib --out-dir dist",
+    "build": "babel lib --out-dir dist && mkdir -p dist/utils/queries && cp -vr lib/utils/queries dist/utils/queries",
     "prepublish": "npm run build"
   },
   "author": "Gabriel Schammah <gabriel@restorando.com>",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "NODE_ENV=test NODE_PATH=src mocha --timeout 1000 --compilers js:babel-core/register --require babel-polyfill ./test/*.js ./test/store/*.js ./test/utils/*.js",
-    "build": "babel lib --out-dir dist && mkdir -p dist/utils/queries && cp -vr lib/utils/queries dist/utils/queries",
+    "build": "babel lib --out-dir dist && mkdir -p dist/utils/queries && cp -vr lib/utils/queries dist/utils",
     "prepublish": "npm run build"
   },
   "author": "Gabriel Schammah <gabriel@restorando.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-query-whitelist",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "A very simple GraphQL query whitelist middleware for express",
   "main": "./dist/index.js",
   "scripts": {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -15,7 +15,7 @@ describe('Query whitelisting middleware', () => {
   const validQuery = 'query ValidQuery { firstName }'
   const validQueryId = 'Hwf+pzIq09drbuQSzDSAXEwuk9HfwrGKw7yFzd1buNM='
   const invalidQuery = 'query InvalidQuery { lastName }'
-  const unauthorizedError = { error: 'Unauthorized query' }
+  const unauthorizedError = { errors: [{ message: 'Unauthorized query' }] }
 
   let store, repository, request
 

--- a/test/utils/query-repository.js
+++ b/test/utils/query-repository.js
@@ -26,6 +26,18 @@ describe('QueryRepository', () => {
     expect(store.queries.get(queryId)).to.deep.equal(expectedQuery)
   })
 
+  it('overrides the operation name', async () => {
+    expect(store.queries.has(queryId)).to.be.false
+
+    await repo.put(query, { operationName: 'foo' })
+
+    expect(store.queries.get(queryId)).to.deep.equal({
+      enabled: true,
+      operationName: 'foo',
+      query: 'query TestQuery {\n  firstName\n}\n'
+    })
+  })
+
   it('gets a query from the store', async () => {
     await repo.put(query)
 


### PR DESCRIPTION
* Use graphql's `formatError` helper
* Handle errors in a better way
* Operation name is now optional if using the `QueryRepository` helper
* Add the option to store graphql and graphiql introspection queries (needed in order to whitelist the introspection queries GraphiQL needs

@jfresco 