### PR TITLE
expose `operationName` instead of `normalizedQuery`

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ Example:
 import { verbose, warn } from 'utils/log'
 
 const validationErrorFn = (req) => {
-  warn(`Query '${req.queryId}' is not in the whitelist`)
-  verbose(`Unauthorized query: ${req.normalizedQuery}`)
+  warn(`Query '${req.operationName} (${req.queryId})' is not in the whitelist`)
+  verbose(`Unauthorized query: ${req.body.query}`)
 }
 
 app.post('/graphql', graphqlWhitelist({ store, validationErrorFn }))

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,10 +30,11 @@ export default ({ store, skipValidationFn = noop, validationErrorFn = noop, stor
         next()
       }
 
-      const { query, enabled } = await repository.get(queryObj.queryId)
-
       req.queryId = queryObj.queryId
-      req.body.query = req.normalizedQuery = query
+      req.operationName = queryObj.operationName
+
+      const { query, enabled } = await repository.get(queryObj.queryId)
+      req.body.query = query
 
       enabled ? next() : unauthorized('QUERY_DISABLED')
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-query-whitelist",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A very simple GraphQL query whitelist middleware for express",
   "main": "./dist/index.js",
   "scripts": {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -68,8 +68,8 @@ describe('Query whitelisting middleware', () => {
         await graphqlWhitelist({ store })(req, res, next)
 
         expect(req.queryId).to.equal(validQueryId)
+        expect(req.operationName).to.equal('ValidQuery')
         expect(req.body.query).to.equal(normalizedQuery)
-        expect(req.normalizedQuery).to.equal(normalizedQuery)
       })
     })
   })


### PR DESCRIPTION
Cambio el orden en el que seteo las propiedades asi en caso de entrar a la excepción de `QueryNotFound`, `req` ya tiene seteadas `operationName` y `queryId` (usadas para loggear el error)

![image](https://cloud.githubusercontent.com/assets/591992/21596620/35d4aeee-d11c-11e6-88f2-67015885fa5c.png)
