### PR TITLE
allow a query to be renamed via api

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -34,8 +34,12 @@ export default (store) => {
   })
 
   router.put('/queries/:id(*)', async (req, res) => {
-    const enabled = req.body.enabled
-    const newProperties = typeof enabled === 'boolean' ? { enabled } : {}
+    const { enabled, operationName } = req.body
+    const newProperties = { enabled, operationName }
+
+    // Manually check each updatable property since they are only 2
+    if (typeof enabled !== 'boolean') delete newProperties.enabled
+    if (!operationName) delete newProperties.operationName
 
     try {
       const query = await repository.update(req.params.id, newProperties)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-query-whitelist",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A very simple GraphQL query whitelist middleware for express",
   "main": "./dist/index.js",
   "scripts": {

--- a/test/api.js
+++ b/test/api.js
@@ -67,8 +67,8 @@ describe('Api', () => {
     it('updates an existing query', done => {
       request
         .put(`/api/queries/${existingQueryId}`)
-        .send({ enabled: false })
-        .expect({ ...fullQuery, enabled: false }, done)
+        .send({ enabled: false, operationName: 'foo' })
+        .expect({ ...fullQuery, enabled: false, operationName: 'foo' }, done)
     })
 
     it('returns a 404 if the query that needs to be updated does not exist', done => {


### PR DESCRIPTION
self-explanatory, needed for the whitelist ui

I consider this as a bug more than a feature (the branch name is wrong, I know)

![rename_operation_name](https://cloud.githubusercontent.com/assets/591992/21792119/484991fc-d6c6-11e6-8a01-ad65fe0e6c1d.gif)
