### PR TITLE
add binary to store all queries that resides in a directory

### DIFF
--- a/lib/utils/gql-whitelist.js
+++ b/lib/utils/gql-whitelist.js
@@ -1,19 +1,5 @@
 #!/usr/bin/env node
 
-/*
-  Config.json example:
-
-  {
-    "redis": {
-      "url": "redis://localhost:6379",
-      "options": {
-        "keyPrefix": "myKeyPrefix",
-        ... (any ioredis option)
-      }
-    }
-  }
-*/
-
 import optimist from 'optimist'
 import { getQueriesFromDir } from './'
 import axios from 'axios'
@@ -22,21 +8,19 @@ const { argv } = optimist
   .usage('Stores the queries residing in the specified directories.\nUsage: gql-whitelist dir1 [dir2] [dir3] ')
   .demand('endpoint')
   .alias('H', 'header')
-  .describe('endpoint', 'Base url of query whitelist API')
+  .describe('endpoint', 'Base URL of query whitelist API')
   .describe('header', 'Header to send to the API: e.g key=value')
 
 const { _: directories, endpoint, header } = argv
 
-const parseHeaders = (headers) => {
-  const result = {}
-
+const parseHeaders = headers => {
   headers = Array.isArray(headers) ? headers : [headers]
-  headers.forEach(header => {
+
+  return headers.reduce((result, header) => {
     const [key, val] = header.split(/=(.+)/)
     result[key] = val
-  })
-
-  return result
+    return result
+  }, {})
 }
 
 const client = axios.create({
@@ -50,9 +34,9 @@ const addQueryToWhitelist = async ({ query, filename }) => {
   try {
     console.log(`Adding query from ${filename}`)
     const { data: { operationName, id } } = await client.post('/queries', { query })
-    console.log(`${operationName} => ${id}`)
+    console.log(`${filename} => ${operationName} => ${id}`)
   } catch (e) {
-    if (e.ressponse) {
+    if (e.response) {
       console.error(e.response.data)
     } else {
       console.error(e)

--- a/lib/utils/gql-whitelist.js
+++ b/lib/utils/gql-whitelist.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/*
+  Config.json example:
+
+  {
+    "redis": {
+      "url": "redis://localhost:6379",
+      "options": {
+        "keyPrefix": "myKeyPrefix",
+        ... (any ioredis option)
+      }
+    }
+  }
+*/
+
+import optimist from 'optimist'
+import path from 'path'
+import { QueryRepository, storeQueriesFromDir } from './'
+import { RedisStore } from '../store'
+
+const { argv } = optimist
+  .usage('Stores the queries residing in the specified directories.\nUsage: gql-whitelist dir1 [dir2] [dir3] ')
+  .demand('config')
+  .describe('config', 'path to the config file')
+
+const { _: directories, config } = argv
+
+const logResult = result => {
+  console.log(result.map(({ id, operationName }) => `${operationName} => ${id}`).join('\n'))
+}
+
+const execute = async () => {
+  let store
+
+  try {
+    const { redis: { url, options } } = require(path.resolve(config))
+    store = new RedisStore(url, options)
+    const repository = new QueryRepository(store)
+
+    await Promise.all(directories.map(dir => storeQueriesFromDir(repository, dir).then(logResult)))
+    console.log('All queries stored successfully')
+  } catch (e) {
+    console.trace(e)
+    process.exitCode = 1
+  } finally {
+    store && store.redisClient.quit()
+  }
+}
+
+execute()

--- a/lib/utils/gql-whitelist.js
+++ b/lib/utils/gql-whitelist.js
@@ -15,30 +15,59 @@
 */
 
 import optimist from 'optimist'
-import path from 'path'
-import { QueryRepository, storeQueriesFromDir } from './'
-import { RedisStore } from '../store'
+import { getQueriesFromDir } from './'
+import axios from 'axios'
 
 const { argv } = optimist
   .usage('Stores the queries residing in the specified directories.\nUsage: gql-whitelist dir1 [dir2] [dir3] ')
-  .demand('config')
-  .describe('config', 'path to the config file')
+  .demand('endpoint')
+  .alias('H', 'header')
+  .describe('endpoint', 'Base url of query whitelist API')
+  .describe('header', 'Header to send to the API: e.g key=value')
 
-const { _: directories, config } = argv
+const { _: directories, endpoint, header } = argv
 
-const logResult = result => {
-  console.log(result.map(({ id, operationName }) => `${operationName} => ${id}`).join('\n'))
+const parseHeaders = (headers) => {
+  const result = {}
+
+  headers = Array.isArray(headers) ? headers : [headers]
+  headers.forEach(header => {
+    const [key, val] = header.split(/=(.+)/)
+    result[key] = val
+  })
+
+  return result
+}
+
+const client = axios.create({
+  baseURL: endpoint,
+  timeout: 10000,
+  maxRedirects: 0,
+  headers: parseHeaders(header)
+})
+
+const addQueryToWhitelist = async ({ query, filename }) => {
+  try {
+    console.log(`Adding query from ${filename}`)
+    const { data: { operationName, id } } = await client.post('/queries', { query })
+    console.log(`${operationName} => ${id}`)
+  } catch (e) {
+    if (e.ressponse) {
+      console.error(e.response.data)
+    } else {
+      console.error(e)
+    }
+  }
 }
 
 const execute = async () => {
   let store
 
   try {
-    const { redis: { url, options } } = require(path.resolve(config))
-    store = new RedisStore(url, options)
-    const repository = new QueryRepository(store)
-
-    await Promise.all(directories.map(dir => storeQueriesFromDir(repository, dir).then(logResult)))
+    await Promise.all(directories.map(async dir => {
+      const queries = await getQueriesFromDir(dir)
+      return Promise.all(queries.map(addQueryToWhitelist))
+    }))
     console.log('All queries stored successfully')
   } catch (e) {
     console.trace(e)

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,3 +1,4 @@
+export storeQueriesFromDir from './store-queries-from-dir'
 export parseQuery from './parse-query'
 export QueryRepository, { QueryNotFoundError } from './query-repository'
 export storeIntrospectionQueries from './store-introspection-queries'

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,4 +1,4 @@
-export storeQueriesFromDir from './store-queries-from-dir'
+export storeQueriesFromDir, { getQueriesFromDir } from './store-queries-from-dir'
 export parseQuery from './parse-query'
 export QueryRepository, { QueryNotFoundError } from './query-repository'
 export storeIntrospectionQueries from './store-introspection-queries'

--- a/lib/utils/store-introspection-queries.js
+++ b/lib/utils/store-introspection-queries.js
@@ -1,22 +1,9 @@
-import fs from 'fs'
 import path from 'path'
 import { introspectionQuery } from 'graphql'
 import { version as graphqlVersion } from 'graphql/package.json'
+import { storeQueriesFromDir } from './'
 
-const resolvePath = (filename = '') => path.join(__dirname, 'queries', filename)
-
-const getQueryFiles = () => {
-  return new Promise((resolve, reject) => {
-    const directory = resolvePath()
-
-    fs.readdir(directory, (err, files) => {
-      if (err) return reject(err)
-      resolve(files.filter(file => /\.graphql$/.test(file)).map(resolvePath))
-    })
-  })
-}
-
-const graphqlFilenameToString = (file) => {
+const operationNameFn = (file) => {
   const filename = path.basename(file, '.graphql')
   let [, app, version] = filename.match(/^(graphi?ql).*?([\d.]+)$/)
   app = app.replace(/[gql]/g, letter => letter.toUpperCase())
@@ -25,20 +12,14 @@ const graphqlFilenameToString = (file) => {
 }
 
 export default async function storeIntrospectionQueries(repository) {
-  const files = await getQueryFiles()
-  let operationName = graphqlFilenameToString(`graphql-introspection-query-${graphqlVersion}.graphql`)
+  const operationName = operationNameFn(`graphql-introspection-query-${graphqlVersion}.graphql`)
+  const introspectionQueriesPath = path.join(__dirname, 'queries')
 
   return Promise.all([
     repository.put(introspectionQuery, { operationName }),
-    ...files.map(file => {
-      fs.readFile(file, (err, data) => {
-        if (err) return console.warn(err)
-
-        operationName = graphqlFilenameToString(file)
-
-        console.info(`Storing ${operationName}`)
-        return repository.put(data.toString(), { operationName })
-      })
-    })
-  ])
+    storeQueriesFromDir(repository, introspectionQueriesPath, { operationNameFn })
+  ]).then(() => {
+    console.log(`Storing bundled introspection query for version ${graphqlVersion}`)
+    console.log('Introspection queries stored successfully')
+  })
 }

--- a/lib/utils/store-introspection-queries.js
+++ b/lib/utils/store-introspection-queries.js
@@ -1,10 +1,10 @@
-import path from 'path'
+import { basename, join } from 'path'
 import { introspectionQuery } from 'graphql'
 import { version as graphqlVersion } from 'graphql/package.json'
 import { storeQueriesFromDir } from './'
 
-const operationNameFn = (file) => {
-  const filename = path.basename(file, '.graphql')
+const getOperationNameFn = (file) => {
+  const filename = basename(file, '.graphql')
   let [, app, version] = filename.match(/^(graphi?ql).*?([\d.]+)$/)
   app = app.replace(/[gql]/g, letter => letter.toUpperCase())
 
@@ -12,12 +12,12 @@ const operationNameFn = (file) => {
 }
 
 export default async function storeIntrospectionQueries(repository) {
-  const operationName = operationNameFn(`graphql-introspection-query-${graphqlVersion}.graphql`)
-  const introspectionQueriesPath = path.join(__dirname, 'queries')
+  const operationName = getOperationNameFn(`graphql-introspection-query-${graphqlVersion}.graphql`)
+  const introspectionQueriesPath = join(__dirname, 'queries')
 
   return Promise.all([
     repository.put(introspectionQuery, { operationName }),
-    storeQueriesFromDir(repository, introspectionQueriesPath, { operationNameFn })
+    storeQueriesFromDir(repository, introspectionQueriesPath, { getOperationNameFn })
   ]).then(() => {
     console.log(`Storing bundled introspection query for version ${graphqlVersion}`)
     console.log('Introspection queries stored successfully')

--- a/lib/utils/store-queries-from-dir.js
+++ b/lib/utils/store-queries-from-dir.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-const findQueries = dir => new Promise((resolve, reject) => {
+const findQueryFiles = dir => new Promise((resolve, reject) => {
   const resolvePath = (filename = '') => path.resolve(dir, filename)
 
   console.log(`Searching for queries in '${resolvePath()}'`)
@@ -12,21 +12,26 @@ const findQueries = dir => new Promise((resolve, reject) => {
   })
 })
 
-const readQueryFile = file => new Promise((resolve, reject) => {
+const readQueryFromFile = file => new Promise((resolve, reject) => {
   fs.readFile(file, (err, data) => {
     if (err) return reject(err)
     resolve(data.toString())
   })
 })
 
+export const getQueriesFromDir = async dir => {
+  const files = await findQueryFiles(dir)
+  return Promise.all(files.map(async filename => ({ query: await readQueryFromFile(filename), filename })))
+}
+
 const identityFn = input => input
 
 export default async (repository, dir, options = {}) => {
-  const queryFiles = await findQueries(dir)
+  const queryFiles = await findQueryFiles(dir)
   const operationNameFn = options.operationNameFn || identityFn
 
   return Promise.all(queryFiles.map(async file => {
     console.log(`Storing query from ${file}`)
-    return repository.put(await readQueryFile(file), { operationName: operationNameFn(file) })
+    return repository.put(await readQueryFromFile(file), { operationName: operationNameFn(file) })
   }))
 }

--- a/lib/utils/store-queries-from-dir.js
+++ b/lib/utils/store-queries-from-dir.js
@@ -28,10 +28,10 @@ const identityFn = input => input
 
 export default async (repository, dir, options = {}) => {
   const queryFiles = await findQueryFiles(dir)
-  const operationNameFn = options.operationNameFn || identityFn
+  const getOperationNameFn = options.getOperationNameFn || identityFn
 
   return Promise.all(queryFiles.map(async file => {
     console.log(`Storing query from ${file}`)
-    return repository.put(await readQueryFromFile(file), { operationName: operationNameFn(file) })
+    return repository.put(await readQueryFromFile(file), { operationName: getOperationNameFn(file) })
   }))
 }

--- a/lib/utils/store-queries-from-dir.js
+++ b/lib/utils/store-queries-from-dir.js
@@ -1,0 +1,32 @@
+import fs from 'fs'
+import path from 'path'
+
+const findQueries = dir => new Promise((resolve, reject) => {
+  const resolvePath = (filename = '') => path.resolve(dir, filename)
+
+  console.log(`Searching for queries in '${resolvePath()}'`)
+
+  fs.readdir(dir, (err, files) => {
+    if (err) return reject(err)
+    resolve(files.filter(file => /\.graphql$/.test(file)).map(resolvePath))
+  })
+})
+
+const readQueryFile = file => new Promise((resolve, reject) => {
+  fs.readFile(file, (err, data) => {
+    if (err) return reject(err)
+    resolve(data.toString())
+  })
+})
+
+const identityFn = input => input
+
+export default async (repository, dir, options = {}) => {
+  const queryFiles = await findQueries(dir)
+  const operationNameFn = options.operationNameFn || identityFn
+
+  return Promise.all(queryFiles.map(async file => {
+    console.log(`Storing query from ${file}`)
+    return repository.put(await readQueryFile(file), { operationName: operationNameFn(file) })
+  }))
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "graphql-query-whitelist",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "A very simple GraphQL query whitelist middleware for express",
   "main": "./dist/index.js",
+  "bin": {
+    "gql-whitelist": "./dist/utils/gql-whitelist.js"
+  },
   "scripts": {
     "lint": "eslint .",
     "test": "NODE_ENV=test NODE_PATH=src mocha --timeout 1000 --compilers js:babel-core/register --require babel-polyfill ./test/*.js ./test/store/*.js ./test/utils/*.js",
-    "build": "babel lib --out-dir dist && mkdir -p dist/utils/queries && cp -vr lib/utils/queries dist/utils",
+    "build": "babel lib --out-dir dist && babel bin && mkdir -p dist/utils/queries && cp -vr lib/utils/queries dist/utils",
     "prepublish": "npm run build"
   },
   "author": "Gabriel Schammah <gabriel@restorando.com>",
@@ -43,6 +46,7 @@
   },
   "repository": "https://www.github.com/restorando/graphql-query-whitelist",
   "dependencies": {
-    "babel-runtime": "^6.18.0"
+    "babel-runtime": "^6.18.0",
+    "optimist": "^0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "repository": "https://www.github.com/restorando/graphql-query-whitelist",
   "dependencies": {
+    "axios": "^0.15.3",
     "babel-runtime": "^6.18.0",
     "optimist": "^0.6.1"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "NODE_ENV=test NODE_PATH=src mocha --timeout 1000 --compilers js:babel-core/register --require babel-polyfill ./test/*.js ./test/store/*.js ./test/utils/*.js",
-    "build": "babel lib --out-dir dist && babel bin && mkdir -p dist/utils/queries && cp -vr lib/utils/queries dist/utils",
+    "build": "babel lib --out-dir dist && mkdir -p dist/utils/queries && cp -vr lib/utils/queries dist/utils",
     "prepublish": "npm run build"
   },
   "author": "Gabriel Schammah <gabriel@restorando.com>",


### PR DESCRIPTION
This PR adds a binary that stores into a redis store (for now) all the queries stored in `.graphql` files inside one or more directories.

Usage:

`gql-whitelist --config ./path/to/config.json ./path/to/dir1 ./path/to/dir2`