### PR TITLE
Fail whitelisting if adding query any query fails

### DIFF
--- a/lib/utils/gql-whitelist.js
+++ b/lib/utils/gql-whitelist.js
@@ -41,6 +41,7 @@ const addQueryToWhitelist = async ({ query, filename }) => {
     } else {
       console.error(e)
     }
+    throw e
   }
 }
 


### PR DESCRIPTION
Fail whitelisting if adding any query fails, this doesn't happens if the query was already added.